### PR TITLE
Usage with a React class as the type attribute

### DIFF
--- a/src/LazyInput.jsx
+++ b/src/LazyInput.jsx
@@ -2,10 +2,10 @@ var React = require('react');
 
 var LazyInput = React.createClass({
   displayName: "LazyInput",
-  propTypes: {                                  // ['text'] or [CustomInput] type of rendered input
-    type: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func
+  propTypes: {
+    type: React.PropTypes.oneOfType([           // by defaut it will use a React.DOM.input (type='text')
+      React.PropTypes.string,                   // ['text'] type of input ('textarea' will create a textarea element, anything else will pass to input)
+      React.PropTypes.func                      // a React component class
     ]),
     lazyLevel: React.PropTypes.number           // [1000]   number of ms to wait before responding to changes in prop.value
     // note: passes through everything but lazyLevel

--- a/src/LazyInput.jsx
+++ b/src/LazyInput.jsx
@@ -2,8 +2,11 @@ var React = require('react');
 
 var LazyInput = React.createClass({
   displayName: "LazyInput",
-  propTypes: {
-    type: React.PropTypes.string,               // ['text'] type of input/textarea
+  propTypes: {                                  // ['text'] or [CustomInput] type of rendered input
+    type: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.func
+    ]),
     lazyLevel: React.PropTypes.number           // [1000]   number of ms to wait before responding to changes in prop.value
     // note: passes through everything but lazyLevel
   },

--- a/src/LazyInput.jsx
+++ b/src/LazyInput.jsx
@@ -56,7 +56,12 @@ var LazyInput = React.createClass({
     return props;
   },
   render: function() {
-    return React.createElement(this.props.type === "textarea" ? "textarea" : "input", this.getProps());
+    var type = this.props.type;
+    if(!type || type === "text") {
+      type = "input";
+    }
+
+    return React.createElement(type, this.getProps());
   }
 
 });

--- a/src/__tests__/LazyInput-test.jsx
+++ b/src/__tests__/LazyInput-test.jsx
@@ -32,6 +32,16 @@ describe('LazyInput', function() {
     var input = TestUtils.renderIntoDocument(<LazyInput type="textarea" />);
     expect(TestUtils.findRenderedDOMComponentWithTag(input, 'textarea')).not.to.be(undefined);
   });
+  it('should render a custom type when a React class is given', function() {
+    var CustomType = React.createClass({
+      render: function() {
+        return <input className="custom" {...this.props} />
+      }
+    });
+
+    var input = TestUtils.renderIntoDocument(<LazyInput type={CustomType} />);
+    expect(TestUtils.findRenderedDOMComponentWithClass(input, 'custom')).not.to.be(undefined);
+  });
 
   describe("props", function() {
     // specificially import props


### PR DESCRIPTION
Hi! We ran into the same problem with input elements being really laggy when the value is constantly going through the flux loop and your component seemed like a nice solution to that.
Unfortunately we have to support old browsers (IE9) and we are using [react-input-placeholder](https://github.com/enigma-io/react-input-placeholder) to polyfill the placeholder attribute for input elements. I came up with no solutions for how to compose your input with the one with the placeholder polyfill exept the one I'm proposing in my pull request. Any ideas how this could be achieved?
