### PR TITLE
Filter out type prop when React class is given

### DIFF
--- a/src/LazyInput.jsx
+++ b/src/LazyInput.jsx
@@ -54,6 +54,9 @@ var LazyInput = React.createClass({
   getProps: function() {
     var props = {};
     for(var key in this.props) { if(key !== 'lazyLevel') { props[key] = this.props[key]; } }
+    if(typeof props.type === 'function') {
+      delete props.type;
+    }
     props.value = this.state.value;
     if(props.onChange) { props.onChange = this.onChange; }
     return props;

--- a/src/__tests__/LazyInput-test.jsx
+++ b/src/__tests__/LazyInput-test.jsx
@@ -83,6 +83,14 @@ describe('LazyInput', function() {
       expect(shallowRenderer.getRenderOutput().props.lazyLevel).to.be(undefined);
     });
 
+    it('should filter out the type prop when React class is given', function() {
+      var CustomType = function () {};
+      var shallowRenderer = TestUtils.createRenderer();
+      shallowRenderer.render(<LazyInput type={CustomType} />);
+      var input = shallowRenderer.getRenderOutput();
+      expect(input.props.type).to.be(undefined);
+    });
+
     it('should redirect onChange to the custom implementation', function() {
       var onChange = function() {};
       var shallowRenderer = TestUtils.createRenderer();


### PR DESCRIPTION
Hi, would it be better not to propagate LazyInput's type property when a custom React class is provided? Otherwise, we are passing the custom react class to itself.
