### PR TITLE
Prepare for React 16: calls to React.createClass

### DIFF
--- a/examples/lazy.js
+++ b/examples/lazy.js
@@ -2,20 +2,22 @@ var React = require('react')
   , ReactDOM = require('react-dom')
   , LazyInput = require('../src/LazyInput');
 
-var LazyInputExample = React.createClass({
-  displayName: 'LazyInputExample',
-  getInitialState: function() {
-    return {
-      value: '',
+class LazyInputExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      return {
+        value: '',
+      };
     };
-  },
-  onChange: function(e) {
+  }
+  onChange(e) {
     this.setState({ value: e.target.value });
-  },
-  onTextAreaChange: function(e) {
+  }
+  onTextAreaChange(e) {
     this.setState({ value: e.target.value });
-  },
-  render: function() {
+  }
+  render() {
     return (
       <div>
         <h2>Component</h2>

--- a/src/LazyInput.jsx
+++ b/src/LazyInput.jsx
@@ -1,34 +1,20 @@
 var React = require('react');
 
-var LazyInput = React.createClass({
-  displayName: "LazyInput",
-  propTypes: {
-    type: React.PropTypes.oneOfType([           // ['text'] type of input/textarea
-      React.PropTypes.string,                     // type of input ('textarea' will create a textarea element, anything else will pass to input)
-      React.PropTypes.func                        // an optional React component class (instead of input/textarea)
-    ]),
-    lazyLevel: React.PropTypes.number           // [1000]      number of ms to wait before responding to changes in prop.value
-    // note: passes through everything but lazyLevel
-  },
-  getDefaultProps: function() {
-    return {
-      type: 'text',
-      lazyLevel: 1000
-    };
-  },
-  getInitialState: function() {
-    return { value: this.props.value };
-  },
-  componentWillReceiveProps: function(nextProps) {
+class LazyInput extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { value: this.props.value };
+  }
+  componentWillReceiveProps(nextProps) {
     this.updateIfNotLazy(nextProps.value);
-  },
-  componentWillUnmount: function() {
+  }
+  componentWillUnmount() {
     if(this.procrastinationTimer) {
       clearTimeout(this.procrastinationTimer);
       this.procrastinating = false;
     }
-  },
-  updateIfNotLazy: function(newValue) {
+  }
+  updateIfNotLazy(newValue) {
     if(!this.procrastinating) {
       if(this.state.value !== newValue) {
         this.setState({ value: newValue, requestedValue: undefined });
@@ -36,33 +22,47 @@ var LazyInput = React.createClass({
     }else {
       this.setState({ requestedValue: newValue });
     }
-  },
-  procrastinate: function() {
+  }
+  procrastinate() {
     this.procrastinating = true;
     if(this.procrastinationTimer) { clearTimeout(this.procrastinationTimer); }
     this.procrastinationTimer = setTimeout(this.ohAlrightAlready, this.props.lazyLevel);
-  },
-  ohAlrightAlready: function() {
+  }
+  ohAlrightAlready() {
     this.procrastinating = false;
     this.updateIfNotLazy(this.state.requestedValue);
-  },
-  onChange: function(event) {
+  }
+  onChange(event) {
     this.procrastinate();
     this.setState({ value: event.target.value });
     this.props.onChange.apply(null, arguments);
-  },
-  getProps: function() {
+  }
+  getProps() {
     var props = {};
     for(var key in this.props) { if(key !== 'lazyLevel') { props[key] = this.props[key]; } }
     props.value = this.state.value;
     if(props.onChange) { props.onChange = this.onChange; }
     return props;
-  },
-  render: function() {
+  }
+  render() {
     var componentType = (typeof this.props.type === 'function') ? this.props.type : (this.props.type === "textarea" ? "textarea" : "input");
     return React.createElement(componentType, this.getProps());
   }
 
-});
+}
+
+LazyInput.defaultProps = {
+  type: 'text',
+  lazyLevel: 1000
+};
+
+LazyInput.propTypes = {
+  type: React.PropTypes.oneOfType([           // ['text'] type of input/textarea
+    React.PropTypes.string,                     // type of input ('textarea' will create a textarea element, anything else will pass to input)
+    React.PropTypes.func                        // an optional React component class (instead of input/textarea)
+  ]),
+  lazyLevel: React.PropTypes.number           // [1000]      number of ms to wait before responding to changes in prop.value
+  // note: passes through everything but lazyLevel
+};
 
 module.exports = LazyInput;

--- a/src/__tests__/LazyInput-test.jsx
+++ b/src/__tests__/LazyInput-test.jsx
@@ -38,11 +38,9 @@ describe('LazyInput', function() {
   });
 
   it('should render a custom type when a React class is given', function() {
-    var CustomType = React.createClass({
-      render: function() {
-        return <input className="custom" {...this.props} />
-      }
-    });
+    var CustomType = function(props) {
+      return <input className="custom" {...props} />
+    };
 
     var input = TestUtils.renderIntoDocument(<LazyInput type={CustomType} />);
     expect(TestUtils.findRenderedDOMComponentWithClass(input, 'custom')).not.to.be(undefined);


### PR DESCRIPTION
With React 15.5.4, I get the following warning:
> Warning: LazyInput: React.createClass is deprecated and will be removed in version 16. Use plain JavaScript classes instead. If you're not yet ready to migrate, create-react-class is available on npm 
as a drop-in replacement.

This PR is a proposal to get rid of the `React.createClass` calls.